### PR TITLE
[640] - 

### DIFF
--- a/src/main/java/com/gepardec/mega/db/repository/StepEntryRepository.java
+++ b/src/main/java/com/gepardec/mega/db/repository/StepEntryRepository.java
@@ -86,10 +86,10 @@ public class StepEntryRepository implements PanacheRepository<StepEntry> {
     }
 
     @Transactional
-    public int closeAssigned(LocalDate startDate, LocalDate endDate, String ownerEmail, Long stepId) {
+    public int updateStateAssigned(LocalDate startDate, LocalDate endDate, String ownerEmail, Long stepId, EmployeeState newState) {
         return update("UPDATE StepEntry s SET s.employeeState = :employeeState WHERE s.id IN (SELECT s.id FROM StepEntry s WHERE s.date BETWEEN :start AND :end AND s.owner.email = :ownerEmail AND s.step.id = :stepId)",
                 Parameters
-                        .with("employeeState", EmployeeState.DONE)
+                        .with("employeeState", newState)
                         .and("start", startDate)
                         .and("end", endDate)
                         .and("ownerEmail", ownerEmail)
@@ -97,10 +97,10 @@ public class StepEntryRepository implements PanacheRepository<StepEntry> {
     }
 
     @Transactional
-    public int closeAssigned(LocalDate startDate, LocalDate endDate, String ownerEmail, String assigneeEmail, Long stepId, String project) {
+    public int updateStateAssigned(LocalDate startDate, LocalDate endDate, String ownerEmail, String assigneeEmail, Long stepId, String project, EmployeeState newState) {
         return update("UPDATE StepEntry s SET s.employeeState = :employeeState WHERE s.id IN (SELECT s.id FROM StepEntry s WHERE s.date BETWEEN :start AND :end AND s.owner.email = :ownerEmail AND s.step.id = :stepId AND s.project like :project AND s.assignee.email = :assigneeEmail)",
                 Parameters
-                        .with("employeeState", EmployeeState.DONE)
+                        .with("employeeState", newState)
                         .and("start", startDate)
                         .and("end", endDate)
                         .and("ownerEmail", ownerEmail)

--- a/src/main/java/com/gepardec/mega/rest/api/StepEntryResource.java
+++ b/src/main/java/com/gepardec/mega/rest/api/StepEntryResource.java
@@ -1,6 +1,7 @@
 package com.gepardec.mega.rest.api;
 
 import com.gepardec.mega.rest.model.EmployeeStepDto;
+import com.gepardec.mega.rest.model.UpdateEmployeeStepDto;
 import com.gepardec.mega.rest.model.ProjectStepDto;
 
 import javax.validation.constraints.NotNull;
@@ -20,14 +21,14 @@ public interface StepEntryResource {
     Response close(@NotNull(message = "{stepEntryResource.parameter.notNull}") EmployeeStepDto employeeStepDto);
 
     @PUT
-    @Path("/closeforoffice")
+    @Path("/updateEmployeeStateForOffice")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Response closeForOffice(@NotNull(message = "{stepEntryResource.parameter.notNull}") EmployeeStepDto employeeStepDto);
+    Response updateEmployeeStateForOffice(@NotNull(message = "{stepEntryResource.parameter.notNull}") UpdateEmployeeStepDto updateEmployeeStepDto);
 
     @PUT
-    @Path("/closeforproject")
+    @Path("/updateEmployeeStateForProject")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Response close(@NotNull(message = "{stepEntryResource.parameter.notNull}") ProjectStepDto projectStepDto);
+    Response updateEmployeeStateForProject(@NotNull(message = "{stepEntryResource.parameter.notNull}") ProjectStepDto projectStepDto);
 }

--- a/src/main/java/com/gepardec/mega/rest/impl/StepEntryResourceImpl.java
+++ b/src/main/java/com/gepardec/mega/rest/impl/StepEntryResourceImpl.java
@@ -4,6 +4,7 @@ import com.gepardec.mega.domain.model.UserContext;
 import com.gepardec.mega.domain.utils.DateUtils;
 import com.gepardec.mega.rest.api.StepEntryResource;
 import com.gepardec.mega.rest.model.EmployeeStepDto;
+import com.gepardec.mega.rest.model.UpdateEmployeeStepDto;
 import com.gepardec.mega.rest.model.ProjectStepDto;
 import com.gepardec.mega.service.api.StepEntryService;
 import io.quarkus.security.Authenticated;
@@ -32,21 +33,23 @@ public class StepEntryResourceImpl implements StepEntryResource {
     }
 
     @Override
-    public Response closeForOffice(final EmployeeStepDto employeeStepDto) {
-        LocalDate from = DateUtils.getFirstDayOfCurrentMonth(employeeStepDto.currentMonthYear());
-        LocalDate to = DateUtils.getLastDayOfCurrentMonth(employeeStepDto.currentMonthYear());
+    public Response updateEmployeeStateForOffice(UpdateEmployeeStepDto updateEmployeeStepDto) {
+        LocalDate from = DateUtils.getFirstDayOfCurrentMonth(updateEmployeeStepDto.currentMonthYear());
+        LocalDate to = DateUtils.getLastDayOfCurrentMonth(updateEmployeeStepDto.currentMonthYear());
 
-        return Response.ok(stepEntryService.setOpenAndAssignedStepEntriesDone(employeeStepDto.employee(), employeeStepDto.stepId(), from, to)).build();
+        return Response.ok(stepEntryService.updateStepEntryStateForEmployee(updateEmployeeStepDto.employee(),
+                updateEmployeeStepDto.stepId(), from, to, updateEmployeeStepDto.newState())).build();
     }
 
     @Override
-    public Response close(final ProjectStepDto projectStepDto) {
-        return Response.ok(stepEntryService.closeStepEntryForEmployeeInProject(
+    public Response updateEmployeeStateForProject(final ProjectStepDto projectStepDto) {
+        return Response.ok(stepEntryService.updateStepEntryStateForEmployeeInProject(
                 projectStepDto.employee(),
                 projectStepDto.stepId(),
                 projectStepDto.projectName(),
                 userContext.getUser().getEmail(),
-                projectStepDto.currentMonthYear()
+                projectStepDto.currentMonthYear(),
+                projectStepDto.newState()
         )).build();
     }
 }

--- a/src/main/java/com/gepardec/mega/rest/model/UpdateEmployeeStepDto.java
+++ b/src/main/java/com/gepardec/mega/rest/model/UpdateEmployeeStepDto.java
@@ -18,15 +18,12 @@ import lombok.extern.jackson.Jacksonized;
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Jacksonized
-public class ProjectStepDto {
+public class UpdateEmployeeStepDto {
     @JsonProperty
     private final Long stepId;
 
     @JsonProperty
     private final Employee employee;
-
-    @JsonProperty
-    private final String projectName;
 
     @JsonProperty
     private final String currentMonthYear;

--- a/src/main/java/com/gepardec/mega/service/api/StepEntryService.java
+++ b/src/main/java/com/gepardec/mega/service/api/StepEntryService.java
@@ -23,8 +23,8 @@ public interface StepEntryService {
     void addStepEntry(final StepEntry stepEntry);
 
     boolean setOpenAndAssignedStepEntriesDone(Employee employee, Long stepId, LocalDate from, LocalDate to);
-
-    boolean closeStepEntryForEmployeeInProject(Employee employee, Long stepId, String project, String assigneeEmail, String currentMonthYear);
+    boolean updateStepEntryStateForEmployee(Employee employee, Long stepId, LocalDate from, LocalDate to, EmployeeState newState);
+    boolean updateStepEntryStateForEmployeeInProject(Employee employee, Long stepId, String project, String assigneeEmail, String currentMonthYear, EmployeeState employeeState);
 
     List<com.gepardec.mega.db.entity.employee.StepEntry> findAllStepEntriesForEmployee(Employee employee, LocalDate from, LocalDate to);
 

--- a/src/main/java/com/gepardec/mega/service/impl/StepEntryServiceImpl.java
+++ b/src/main/java/com/gepardec/mega/service/impl/StepEntryServiceImpl.java
@@ -97,15 +97,20 @@ public class StepEntryServiceImpl implements StepEntryService {
 
     @Override
     public boolean setOpenAndAssignedStepEntriesDone(Employee employee, Long stepId, LocalDate from, LocalDate to) {
-        return stepEntryRepository.closeAssigned(from, to, employee.getEmail(), stepId) > 0;
+        return stepEntryRepository.updateStateAssigned(from, to, employee.getEmail(), stepId, EmployeeState.DONE) > 0;
     }
 
     @Override
-    public boolean closeStepEntryForEmployeeInProject(Employee employee, Long stepId, String project, String assigneeEmail, String currentMonthYear) {
+    public boolean updateStepEntryStateForEmployee(Employee employee, Long stepId, LocalDate from, LocalDate to, EmployeeState newState) {
+        return stepEntryRepository.updateStateAssigned(from, to, employee.getEmail(), stepId, newState) > 0;
+    }
+
+    @Override
+    public boolean updateStepEntryStateForEmployeeInProject(Employee employee, Long stepId, String project, String assigneeEmail, String currentMonthYear, EmployeeState newState) {
         LocalDate fromDate = DateUtils.getFirstDayOfCurrentMonth(currentMonthYear);
         LocalDate toDate = DateUtils.getLastDayOfCurrentMonth(currentMonthYear);
 
-        return stepEntryRepository.closeAssigned(fromDate, toDate, employee.getEmail(), assigneeEmail, stepId, project) > 0;
+        return stepEntryRepository.updateStateAssigned(fromDate, toDate, employee.getEmail(), assigneeEmail, stepId, project, newState) > 0;
     }
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -135,6 +135,7 @@ mp:
           - "daniel.rasztovich@gepardec.com"
           - "theresa.mueller@gepardec.com"
           - "michael.leitner@gepardec.com"
+          - "simon.bauer@gepardec.com"
 
 ## TEST Properties
 "%test":

--- a/src/test/java/com/gepardec/mega/db/repository/StepEntryRepositoryTest.java
+++ b/src/test/java/com/gepardec/mega/db/repository/StepEntryRepositoryTest.java
@@ -110,55 +110,55 @@ class StepEntryRepositoryTest {
     }
 
     @Test
-    void closeAssigned_whenMethodIsCalledWithCorrectParameters_thenClosesAssignedAndReturnsOne() {
+    void updateStateAssigned_whenMethodIsCalledWithCorrectParameters_thenClosesAssignedAndReturnsOne() {
         persistEntities();
 
-        int result = stepEntryRepository.closeAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, stepEntry.getStep().getId());
+        int result = stepEntryRepository.updateStateAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, stepEntry.getStep().getId(), EmployeeState.DONE);
 
         assertThat(result).isEqualTo(1);
     }
 
     @Test
-    void closeAssigned_whenMethodIsCalledWithEmailWithNullValue_thenReturnsZeroIntegerAndDoesntCloseAssigned() {
+    void updateStateAssigned_whenMethodIsCalledWithEmailWithNullValue_thenReturnsZeroIntegerAndDoesntCloseAssigned() {
         persistEntities();
 
-        int result = stepEntryRepository.closeAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), null, stepEntry.getStep().getId());
+        int result = stepEntryRepository.updateStateAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), null, stepEntry.getStep().getId(), EmployeeState.DONE);
 
         assertThat(result).isZero();
     }
 
     @Test
-    void closeAssigned_whenMethodIsCalledWithCorrectParameters_thenClosesAssignedAndReturnsIntegerOne() {
+    void updateStateAssigned_whenMethodIsCalledWithCorrectParameters_thenClosesAssignedAndReturnsIntegerOne() {
         persistEntities();
 
-        int result = stepEntryRepository.closeAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, EMAIL, stepEntry.getStep().getId(), project.getName());
+        int result = stepEntryRepository.updateStateAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, EMAIL, stepEntry.getStep().getId(), project.getName(), EmployeeState.DONE);
 
         assertThat(result).isEqualTo(1);
     }
 
     @Test
-    void closeAssigned_whenMethodIsCalledWithEmptyProjectParameter_thenReturnsIntegerOne() {
+    void updateStateAssigned_whenMethodIsCalledWithEmptyProjectParameter_thenReturnsIntegerOne() {
         persistEntities();
 
-        int result = stepEntryRepository.closeAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, EMAIL, stepEntry.getStep().getId(), "");
+        int result = stepEntryRepository.updateStateAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, EMAIL, stepEntry.getStep().getId(), "", EmployeeState.DONE);
 
         assertThat(result).isZero();
     }
 
     @Test
-    void closeAssigned_whenMethodIsCalledWithEmptyAssigneParameter_thenReturnsIntegerOne() {
+    void updateStateAssigned_whenMethodIsCalledWithEmptyAssigneParameter_thenReturnsIntegerOne() {
         persistEntities();
 
-        int result = stepEntryRepository.closeAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, "", stepEntry.getStep().getId(), project.getName());
+        int result = stepEntryRepository.updateStateAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), EMAIL, "", stepEntry.getStep().getId(), project.getName(), EmployeeState.DONE);
 
         assertThat(result).isZero();
     }
 
     @Test
-    void closeAssigned_whenMethodIsCalledWithEmptyOwnerParameter_thenReturnsIntegerOne() {
+    void updateStateAssigned_whenMethodIsCalledWithEmptyOwnerParameter_thenReturnsIntegerOne() {
         persistEntities();
 
-        int result = stepEntryRepository.closeAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), "", EMAIL, stepEntry.getStep().getId(), project.getName());
+        int result = stepEntryRepository.updateStateAssigned(localDateTime.toLocalDate(), localDateTime.toLocalDate(), "", EMAIL, stepEntry.getStep().getId(), project.getName(), EmployeeState.DONE);
 
         assertThat(result).isZero();
     }

--- a/src/test/java/com/gepardec/mega/service/impl/stepentry/StepEntryServiceImplTest.java
+++ b/src/test/java/com/gepardec/mega/service/impl/stepentry/StepEntryServiceImplTest.java
@@ -22,8 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -121,8 +120,9 @@ class StepEntryServiceImplTest {
 
     @Test
     void setOpenAndAssignedStepEntriesDone_when0_thenFalse() {
-        when(stepEntryRepository.closeAssigned(ArgumentMatchers.any(LocalDate.class),
-                ArgumentMatchers.any(LocalDate.class), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong()))
+        when(stepEntryRepository.updateStateAssigned(ArgumentMatchers.any(LocalDate.class),
+                ArgumentMatchers.any(LocalDate.class), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong(),
+                argThat(EmployeeState.DONE::equals)))
                 .thenReturn(0);
 
         Employee employee = createEmployee();
@@ -134,8 +134,9 @@ class StepEntryServiceImplTest {
 
     @Test
     void setOpenAndAssignedStepEntriesDone_when1_thenTrue() {
-        when(stepEntryRepository.closeAssigned(ArgumentMatchers.any(LocalDate.class),
-                ArgumentMatchers.any(LocalDate.class), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong()))
+        when(stepEntryRepository.updateStateAssigned(ArgumentMatchers.any(LocalDate.class),
+                ArgumentMatchers.any(LocalDate.class), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong(),
+                argThat(EmployeeState.DONE::equals)))
                 .thenReturn(1);
 
         Employee employee = createEmployee();


### PR DESCRIPTION
States (OPEN / DONE) von der Office und Projekt View sollen auch von DONE wieder zurück auf OPEN gesetzt werden können.

Bisher gab es nur Methoden, die fix den Status auf Close gesetzt haben. Diese wurden größenteils (in den Endpunkten aufjedenfall) aufgeräumt und "sprechender" benannt. Sie benötigen jetzt einen newState. Eine Close Methode bleibt vorerst noch in StepEntryResourceImpl vorhanden, weil MonthlyReport (GUI) + ein paar Unit Tests im Backend sie benötigt. Der Issue 640 betrifft erstmal nur Office und Projekt View.

Grund für UpdateEmployeeStepDto.java Klasse:
Weil die originale "EmployeeStateDto" Klasse noch verwendet wird (für /close bei monthlyReport). Um diese nicht zu verändern, wurde eine neue Klasse mit Prefix "Update" erstellt, die sie um eine Prop "newState" erweitert.

Die ProjectStepDto Klasse wird nicht mehr im kontext "nur closen" verwendet, sondern nur noch mehr bei state update methoden. Daher wurde diese DIREKT erweitert, im Gegensatz zu EmployeeStateDto. (Wenn Umbau bei Monthyly Report auch erfolgen soll, dann sollte die UpdateEmployeeStepDto auch gelöscht werden und stattdessen EmployeeStateDto um newState erweitern und verwenden)