### PR TITLE
Change packaging and containerfile to match quarkus defaults

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,13 +1,12 @@
-FROM openjdk:11.0-jre-slim
+FROM registry.access.redhat.com/ubi8/openjdk-11:latest
 ENV TZ="Europe/Vienna"
 
-WORKDIR /work/
-RUN chown :root /work \
-    && chmod "g+rwX" /work \
-    && chown :root /work
+USER jboss
 
-COPY target/*-runner.jar /work/application.jar
-# COPY target/lib/* /work/lib/
+COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 target/quarkus-app/*.jar /deployments/
+COPY --chown=185 target/quarkus-app/app/ /deployments/app/
+COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 ARG BRANCH
 ARG COMMIT
@@ -19,5 +18,5 @@ ENV COMMIT=$COMMIT
 ENV VERSION=$VERSION
 
 EXPOSE 8080
-
-CMD ["java","-jar","application.jar","-Dquarkus.http.host=0.0.0.0"]
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,5 @@
 # GLOBAL Properties
 quarkus:
-  package:
-    type: "uber-jar"
 
   scheduler:
     enabled: true


### PR DESCRIPTION
In our lf project we struggled to activate the jmx port.
it wont work with the uber jar, really do not know why.
